### PR TITLE
Avoid startup deadlock when Initialize() unpatches FejdStartup.Awake

### DIFF
--- a/ServerCharacters/ServerCharacters.cs
+++ b/ServerCharacters/ServerCharacters.cs
@@ -33,6 +33,7 @@ public class ServerCharacters : BaseUnityPlugin
 	public const int SingleCharacterModeDisconnectMagic = 845979243;
 
 	public static readonly ConfigSync configSync = new(ModGUID) { DisplayName = ModName, CurrentVersion = ModVersion, MinimumRequiredVersion = "1.4.16" };
+	private static bool initialized;
 
 	private static ConfigEntry<Toggle> serverConfigLocked = null!;
 	public static ConfigEntry<Toggle> singleCharacterMode = null!;
@@ -142,7 +143,11 @@ public class ServerCharacters : BaseUnityPlugin
 
 	public static void Initialize()
 	{
-		harmony.Unpatch(AccessTools.DeclaredMethod(typeof(FejdStartup), nameof(Awake)), HarmonyPatchType.Postfix, harmony.Id);
+		if (initialized)
+		{
+			return;
+		}
+		initialized = true;
 
 		if (!serverListenAddress.Value.IsNullOrWhiteSpace())
 		{


### PR DESCRIPTION
## Summary
- avoid calling `Harmony.Unpatch()` from the `FejdStartup.Awake` postfix while that wrapper is still executing
- guard `Initialize()` so startup logic only runs once
- fixes a startup freeze I reproduced in Valheim on macOS Apple Silicon

## Repro
- enable `ServerCharacters`
- launch Valheim on macOS Apple Silicon
- the game reaches `Render threading mode:MultiThreaded` and then hangs before the main menu

## Validation
- I reproduced the freeze locally
- I sampled the hung process with `lldb` and resolved the managed stack to:
  `ServerCharacters.Initialize() -> Harmony.Unpatch() -> MonoMod.RuntimeDetour.DetourSyncInfo.WaitForNoActiveCalls()`
- after this change, the same setup reaches `Starting music menu`

## AI disclosure
This patch was generated with AI assistance from Codex based on GPT-5.4 and then validated locally by me. I am primarily a frontend web developer and I am not deeply comfortable in this language/codebase yet, so I completely understand if you do not want to review or merge AI-assisted changes. If this is not useful, please feel free to close it.
